### PR TITLE
Add remote interface for pipe_lookup

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -305,9 +305,16 @@ local function validate_connector(underground, item_pipe)
     local underground_prototype = prototypes.entity[underground]
     local pipe_prototype = prototypes.entity[item_pipe.entity]
 
-    if not prototypes.item[item_pipe.item]
-    or not pipe_prototype or pipe_prototype.type ~= "pipe"
-    or not underground_prototype or underground_prototype.type ~= "pipe-to-ground" do
+    ---@type table<string, true>
+    local pipe_items = {}
+    for _, stack in pairs(pipe_prototype.items_to_place_this) do
+        pipe_items[stack.name] = true
+    end
+
+    if not pipe_items[item_pipe.item] -- The item needs to be able to place the pipe
+    or not prototypes.item[item_pipe.item] -- The item needs to exist (theoretically we can skip this since it was in an items_to_place_this)
+    or not pipe_prototype or pipe_prototype.type ~= "pipe" -- The pipe needs to be an actual pipe
+    or not underground_prototype or underground_prototype.type ~= "pipe-to-ground" then -- The underground needs to be an actual underground
         error("Given underground and pipe are not valid: "..underground.." -> "..serpent.line(item_pipe))
     end
 

--- a/control.lua
+++ b/control.lua
@@ -295,4 +295,64 @@ end
 script.on_init(rebuild_index)
 script.on_configuration_changed(rebuild_index)
 
+remote.add_interface("automatic-underground-pipe-connectors", {
+    --- Allows mods to see what undergrounds are considered
+    ---@return PipeLookup
+    get_undergrounds = function()
+        return storage.pipe_lookup
+    end,
+    --- Allows mods to completely overwrite undergrounds
+    ---@param PipeLookup
+    set_undergrounds = function(new_lookup)
+        -- To make sure the new lookup is valid
+        for underground, item_pipe in pairs(new_lookup) do
+            -- To make sure the given table doesn't have extra fields
+            item_pipe = {item = item_pipe.item, entity = item_pipe.entity}
+            new_lookup[underground] = item_pipe
+            local underground_prototype = prototypes.entity[underground]
+            local pipe_prototype = prototypes.entity[item_pipe.entity]
+
+            if not prototypes.item[item_pipe.item]
+            or not pipe_prototype or pipe_prototype.type ~= "pipe"
+            or not underground_prototype or underground_prototype.type ~= "pipe-to-ground" do
+                error("Given underground and pipe are not valid: "..underground.." -> "..serpent.line(item_pipe))
+            end
+        end
+
+        storage.pipe_lookup = new_lookup
+    end,
+    --- Allows mods to add underground and pipe connections for when they don't follow the expected recipe pattern.
+    ---@param new_undergrounds PipeLookup
+    add_undergrounds = function(new_undergrounds)
+        for underground, item_pipe in pairs(new_undergrounds) do
+            -- To make sure the given table doesn't have extra fields
+            item_pipe = {item = item_pipe.item, entity = item_pipe.entity}
+            local underground_prototype = prototypes.entity[underground]
+            local pipe_prototype = prototypes.entity[item_pipe.entity]
+
+            if not prototypes.item[item_pipe.item]
+            or not pipe_prototype or pipe_prototype.type ~= "pipe"
+            or not underground_prototype or underground_prototype.type ~= "pipe-to-ground" do
+                error("Given underground and pipe are not valid: "..underground.." -> "..serpent.line(item_pipe))
+            end
+
+            if storage.pipe_lookup[underground] then
+                log("Overriding the pipe for '"..underground.."' with "..serpent.block(item_pipe))
+            end
+
+            storage.pipe_lookup[underground] = item_pipe
+        end
+    end,
+    --- Allows mods to remove undergrounds just in case
+    ---@param old_undergrounds string[]
+    remove_undergrounds = function(old_undergrounds)
+        for _, underground in pairs(old_undergrounds) do
+            if storage.pipe_lookup[underground] then
+                log("Removing the pipe for '"..underground.."'")
+                storage.pipe_lookup[underground] = nil
+            end
+        end
+    end,
+})
+
 script.on_event(defines.events.on_built_entity, on_built_entity, {{filter="type",type="pipe-to-ground"},{filter="ghost_type",type="pipe-to-ground"}})

--- a/control.lua
+++ b/control.lua
@@ -328,7 +328,7 @@ remote.add_interface("automatic-underground-pipe-connectors", {
         return storage.pipe_lookup
     end,
     --- Allows mods to completely overwrite undergrounds
-    ---@param PipeLookup
+    ---@param new_lookup PipeLookup
     set_undergrounds = function(new_lookup)
         -- To make sure the new lookup is valid
         for underground, item_pipe in pairs(new_lookup) do

--- a/control.lua
+++ b/control.lua
@@ -295,6 +295,25 @@ end
 script.on_init(rebuild_index)
 script.on_configuration_changed(rebuild_index)
 
+--- Filters out extra fields in the item_pipe and makes sure the references are valid entities and item
+---@param underground string
+---@param item_pipe {item:string, entity:string}
+---@return {item:string, entity:string} item_pipe Has been filtered of extra fields
+local function validate_connector(underground, item_pipe)
+    -- Filter out the extra fields
+    item_pipe = {item = item_pipe.item, entity = item_pipe.entity}
+    local underground_prototype = prototypes.entity[underground]
+    local pipe_prototype = prototypes.entity[item_pipe.entity]
+
+    if not prototypes.item[item_pipe.item]
+    or not pipe_prototype or pipe_prototype.type ~= "pipe"
+    or not underground_prototype or underground_prototype.type ~= "pipe-to-ground" do
+        error("Given underground and pipe are not valid: "..underground.." -> "..serpent.line(item_pipe))
+    end
+
+    return item_pipe
+end
+
 remote.add_interface("automatic-underground-pipe-connectors", {
     --- Allows mods to see what undergrounds are considered
     ---@return PipeLookup
@@ -306,17 +325,7 @@ remote.add_interface("automatic-underground-pipe-connectors", {
     set_undergrounds = function(new_lookup)
         -- To make sure the new lookup is valid
         for underground, item_pipe in pairs(new_lookup) do
-            -- To make sure the given table doesn't have extra fields
-            item_pipe = {item = item_pipe.item, entity = item_pipe.entity}
-            new_lookup[underground] = item_pipe
-            local underground_prototype = prototypes.entity[underground]
-            local pipe_prototype = prototypes.entity[item_pipe.entity]
-
-            if not prototypes.item[item_pipe.item]
-            or not pipe_prototype or pipe_prototype.type ~= "pipe"
-            or not underground_prototype or underground_prototype.type ~= "pipe-to-ground" do
-                error("Given underground and pipe are not valid: "..underground.." -> "..serpent.line(item_pipe))
-            end
+            new_lookup[underground] = validate_connector(underground, item_pipe)
         end
 
         storage.pipe_lookup = new_lookup
@@ -325,22 +334,7 @@ remote.add_interface("automatic-underground-pipe-connectors", {
     ---@param new_undergrounds PipeLookup
     add_undergrounds = function(new_undergrounds)
         for underground, item_pipe in pairs(new_undergrounds) do
-            -- To make sure the given table doesn't have extra fields
-            item_pipe = {item = item_pipe.item, entity = item_pipe.entity}
-            local underground_prototype = prototypes.entity[underground]
-            local pipe_prototype = prototypes.entity[item_pipe.entity]
-
-            if not prototypes.item[item_pipe.item]
-            or not pipe_prototype or pipe_prototype.type ~= "pipe"
-            or not underground_prototype or underground_prototype.type ~= "pipe-to-ground" do
-                error("Given underground and pipe are not valid: "..underground.." -> "..serpent.line(item_pipe))
-            end
-
-            if storage.pipe_lookup[underground] then
-                log("Overriding the pipe for '"..underground.."' with "..serpent.block(item_pipe))
-            end
-
-            storage.pipe_lookup[underground] = item_pipe
+            storage.pipe_lookup[underground] = validate_connector(underground, item_pipe)
         end
     end,
     --- Allows mods to remove undergrounds just in case


### PR DESCRIPTION
I only really wanted `add_undergrounds`, but I thought I'd add the other interfaces while I was at it. Admittedly I haven't actually _tested_, but this was a proposition to get your thoughts on it.

The whole idea of this is that [Periodic Madness](https://mods.factorio.com/mod/periodic-madness) doesn't follow the pattern of requiring the pipe for the undergrounds, and I would like to make it compatible.