### PR TITLE
Update for Factorio 2.1, release 2.0.12

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,11 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.0.12
+Date: 2026-06-25
+  Changes:
+    - Updated for Factorio 2.1
+  Compatibility:
+    - Migrated neighbor fluidbox checks to entity.fluids_count and entity.get_fluid_box_pipe_connections
+---------------------------------------------------------------------------------------------------
 Version: 2.0.11
 Date: 2025-06-11
   Changes:

--- a/control.lua
+++ b/control.lua
@@ -51,9 +51,8 @@ end
 ---@param position MapPosition
 ---@return boolean place
 local function should_place_based_on_neighbor_fluidbox_prototypes(entity, position)
-    local fluidbox = entity.fluidbox
-    for i = 1, #fluidbox do
-        for _, pipe_connection in pairs( fluidbox.get_pipe_connections(i) ) do
+    for i = 1, entity.fluids_count do
+        for _, pipe_connection in pairs( entity.get_fluid_box_pipe_connections(i) ) do
             -- floor operation rounds to nearest 0.5 to mimic pipe connection snapping behavior
             if position[1] == math.floor( ( pipe_connection.target_position.x + 0.25 ) * 2 ) / 2 and
                position[2] == math.floor( ( pipe_connection.target_position.y + 0.25 ) * 2 ) / 2 then
@@ -214,8 +213,7 @@ local function on_built_entity(event)
                 end
                 if  ( entity_type ~= "pipe" and entity_type ~= "pipe-to-ground"
                     ) and (
-                        neighbor_entity.fluidbox and
-                        #neighbor_entity.fluidbox > 0
+                        neighbor_entity.fluids_count > 0
                     )
                 then
                     if should_place_based_on_neighbor_fluidbox_prototypes(neighbor_entity, pipe_position) then

--- a/info.json
+++ b/info.json
@@ -1,10 +1,13 @@
 {
   "name": "automatic-underground-pipe-connectors",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "title": "Automatic Underground Pipe Connectors",
   "author": "Sparr",
   "contact": "sparr0@gmail.com",
   "homepage": "https://github.com/sparr/factorio-mod-automatic-underground-pipe-connectors",
-  "factorio_version": "2.0",
-  "description": "Automatically place a pipe when two undergrounds are placed at a corner or one space apart"
+  "factorio_version": "2.1",
+  "description": "Automatically place a pipe when two undergrounds are placed at a corner or one space apart",
+  "dependencies": [
+    "base >= 2.1"
+  ]
 }


### PR DESCRIPTION
Migrate neighbor fluidbox checks to the 2.1 LuaEntity API: use entity.fluids_count and entity.get_fluid_box_pipe_connections instead of indexing entity.fluidbox and calling fluidbox.get_pipe_connections. Declare base >= 2.1 dependency.